### PR TITLE
Fix Inworld TTS context tracking

### DIFF
--- a/src/pipecat/services/inworld.py
+++ b/src/pipecat/services/inworld.py
@@ -82,7 +82,7 @@ class InworldTTSService(InterruptibleWordTTSService):
     ):
         super().__init__(
             aggregate_sentences=True,
-            push_text_frames=False,
+            push_text_frames=True,
             push_stop_frames=True,
             pause_frame_processing=True,
             sample_rate=sample_rate,
@@ -265,16 +265,10 @@ class InworldTTSService(InterruptibleWordTTSService):
                     frame = TTSAudioRawFrame(audio, self.sample_rate, 1)
                     await self.push_frame(frame)
 
-                # Process word alignment timestamps
-                timestamp_info = chunk.get("timestampInfo") or {}
-                word_alignment = timestamp_info.get("wordAlignment")
-                if word_alignment and word_alignment.get("words"):
-                    word_times = calculate_word_times(
-                        word_alignment, self._cumulative_time
-                    )
-                    if word_times:
-                        await self.add_word_timestamps(word_times)
-                        self._cumulative_time = word_times[-1][1]
+                # Note: Word alignment timestamps are skipped because with
+                # push_text_frames=True, the base class pushes full sentence
+                # TTSTextFrame after each run_tts. Using word alignment here
+                # would duplicate text in the context aggregator.
 
             elif result.get("flushCompleted"):
                 logger.debug(f"Inworld flush completed for context {result.get('contextId')}")


### PR DESCRIPTION
## Summary
- Switch Inworld TTS from `push_text_frames=False` to `push_text_frames=True` so the base class pushes full sentence `TTSTextFrame` and `LLMFullResponseEndFrame` downstream
- Skip word alignment timestamp processing to avoid duplicate text in the context aggregator

## Problem
With `push_text_frames=False`, `LLMFullResponseEndFrame` never reached the context aggregator. Context aggregation only triggered on user interruption, capturing partial word timestamp text. The LLM saw incomplete context (e.g. only "¡Hola" instead of the full greeting) and looped its response.

## Test plan
- [x] Local test call with Inworld TTS — bot speaks full greeting without looping
- [x] Verified "Aggregating because LLMFullResponseEndFrame" fires after every LLM response
- [ ] Production deploy and monitor Inworld TTS calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
