### PR TITLE
fix(openai): report cache_read_input_tokens in LLM usage metrics

### DIFF
--- a/src/pipecat/services/openai.py
+++ b/src/pipecat/services/openai.py
@@ -241,10 +241,20 @@ class BaseOpenAILLMService(LLMService):
             logger.debug(f"{self}: {chunk}")
             
             if chunk.usage:
+                # prompt_tokens INCLUDES cached tokens; report the cache-hit
+                # share separately so cost tracking can bill it at the
+                # discounted cached rate.
+                prompt_details = getattr(chunk.usage, "prompt_tokens_details", None)
+                cached_tokens = (
+                    getattr(prompt_details, "cached_tokens", 0) or 0
+                    if prompt_details
+                    else 0
+                )
                 tokens = LLMTokenUsage(
                     prompt_tokens=chunk.usage.prompt_tokens,
                     completion_tokens=chunk.usage.completion_tokens,
                     total_tokens=chunk.usage.total_tokens,
+                    cache_read_input_tokens=cached_tokens,
                 )
                 await self.start_llm_usage_metrics(tokens)
 


### PR DESCRIPTION
OpenAI's `prompt_tokens` INCLUDES automatically-cached prefix tokens (50% discount, prompts >=1024 tokens). Surface the cache-hit share via `LLMTokenUsage.cache_read_input_tokens` so cost tracking can bill it at the cached rate.

## ⚠️ DEPLOY ORDER
**Merge only after callbook-backend #257 is live in prod.** callbook-core instances install this repo's `main` unpinned at boot (`startup.sh`: `git reset --hard origin/main` + `pip install -r requirements.txt`), and the old backend formula double-counts cached tokens (full rate + cached rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)