### PR TITLE
fix(deepgram): make _disconnect non-reentrant (stops teardown RecursionError)

### DIFF
--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -704,6 +704,9 @@ class DeepgramSTTService(STTService):
         # FIX: Add debouncing for error handling to prevent race conditions
         self._reconnecting = False
         self._reconnect_lock = asyncio.Lock()
+        # Re-entrancy guard for _disconnect (prevents the error -> _on_error ->
+        # _disconnect path from recursing during teardown — see _disconnect).
+        self._disconnecting = False
 
         self._setup_sibling_deepgram()
 
@@ -1185,10 +1188,24 @@ class DeepgramSTTService(STTService):
             await self._on_error(error=e)
 
     async def _disconnect(self):
+        # Re-entrancy guard. The Deepgram error path (_on_error -> _disconnect)
+        # can fire again *while we are already disconnecting* — e.g. cancelling
+        # the handler task surfaces another connection error. Previously this
+        # recursed (each level re-cancelling the not-yet-cleared handler task)
+        # until a RecursionError, which the `except` below swallowed, leaving the
+        # pipeline teardown half-done and the call wedged until the max-duration
+        # cap. Make _disconnect idempotent and non-reentrant.
+        if self._disconnecting:
+            return
+        self._disconnecting = True
         try:
-            if self._async_handler_task:
-                await self.cancel_task(self._async_handler_task)
-                self._async_handler_task = None
+            handler_task = self._async_handler_task
+            # Clear the reference BEFORE awaiting cancellation so a re-entrant
+            # call (or a concurrent reconnect) can't grab and cancel it again.
+            self._async_handler_task = None
+            # Never cancel the task we are currently running inside of.
+            if handler_task is not None and handler_task is not asyncio.current_task():
+                await self.cancel_task(handler_task)
 
             # FIX: Check connection exists before checking is_connected to prevent AttributeError
             if self._connection is not None:
@@ -1216,6 +1233,7 @@ class DeepgramSTTService(STTService):
         finally:
             # Ensure connection is always cleared even if outer try fails
             self._connection = None
+            self._disconnecting = False
 
     async def start_metrics(self):
         await self.start_ttfb_metrics()

--- a/tests/test_deepgram_stt_service.py
+++ b/tests/test_deepgram_stt_service.py
@@ -859,5 +859,64 @@ class TestFastResponseAccumulation(unittest.TestCase):
         self.assertEqual(len(self.stt_service._accum_transcription_frames), 3)
 
 
+class TestDisconnectReentrancy(unittest.TestCase):
+    """Regression tests for the _disconnect re-entrancy guard.
+
+    The Deepgram error path (_on_error -> _disconnect) could re-enter
+    _disconnect while it was already tearing down. Because _async_handler_task
+    was only cleared *after* awaiting its cancellation, each re-entry re-cancelled
+    the same not-yet-cleared task, recursing until a RecursionError — which the
+    broad `except` in _disconnect swallowed, leaving the pipeline teardown
+    half-done and the call wedged until the max-duration cap.
+    """
+
+    def setUp(self):
+        self.stt_service = DeepgramSTTService(api_key="test_key", sample_rate=16000)
+        self.stt_service._connection = None  # skip the websocket cleanup block
+
+    @pytest.mark.asyncio
+    async def test_reentrant_disconnect_does_not_recurse(self):
+        """Re-entry during teardown must be a no-op, not unbounded recursion."""
+        cancel_calls = {"n": 0}
+
+        async def reentrant_cancel(task):
+            cancel_calls["n"] += 1
+            # Simulate the error -> _on_error -> _disconnect re-entry.
+            await self.stt_service._disconnect()
+
+        self.stt_service._async_handler_task = object()  # truthy 'task'
+        self.stt_service.cancel_task = AsyncMock(side_effect=reentrant_cancel)
+
+        await self.stt_service._disconnect()
+
+        # Without the guard this was ~496 (recursion depth limit); with it, 1.
+        self.assertEqual(cancel_calls["n"], 1)
+        self.assertIsNone(self.stt_service._async_handler_task)
+        self.assertFalse(self.stt_service._disconnecting)
+
+    @pytest.mark.asyncio
+    async def test_disconnect_does_not_self_cancel(self):
+        """If the handler task is the current task, it must not be cancelled."""
+        self.stt_service._async_handler_task = asyncio.current_task()
+        self.stt_service.cancel_task = AsyncMock()
+
+        await self.stt_service._disconnect()
+
+        self.stt_service.cancel_task.assert_not_called()
+        self.assertIsNone(self.stt_service._async_handler_task)
+
+    @pytest.mark.asyncio
+    async def test_normal_disconnect_cancels_handler_once(self):
+        """Normal teardown cancels the handler exactly once and clears refs."""
+        self.stt_service._async_handler_task = object()
+        self.stt_service.cancel_task = AsyncMock()
+
+        await self.stt_service._disconnect()
+
+        self.assertEqual(self.stt_service.cancel_task.await_count, 1)
+        self.assertIsNone(self.stt_service._async_handler_task)
+        self.assertFalse(self.stt_service._disconnecting)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem
Voicemail/end hangups wedge: `DeepgramSTTService._disconnect` recurses until `RecursionError: maximum recursion depth exceeded`, which its broad `except` swallows — leaving pipeline teardown half-done so the call rides to the 900s max-duration cap. This is the root cause behind the Biofinance 15-min voicemail burn (callbook-core #124 is the downstream watchdog mitigation; this is the real fix).

## Cause
The Deepgram error path (`_on_error` → `_disconnect`) re-enters `_disconnect` while it's already tearing down (cancelling the handler task surfaces another connection error). `_async_handler_task` was cleared only **after** awaiting its cancellation, so each re-entry re-cancelled the same not-yet-cleared task → unbounded recursion (~496 deep, the recursion limit).

## Fix (surgical)
- `_disconnecting` re-entrancy guard → `_disconnect` is idempotent/non-reentrant
- clear `_async_handler_task` **before** awaiting its cancel
- never cancel the task we're currently running inside of (`asyncio.current_task()`)

## Tests
New `TestDisconnectReentrancy` (3 cases): re-entry no longer recurses (cancel called **1×, was ~496**), self-cancel avoided, normal teardown unchanged. **Full deepgram suite: 37 passed.**

## Rollout note
Shared fork — rolls out to callbook-core **and** recaudo-core on their next instance refresh. Happy-path teardown is unchanged (verified); the guard only affects the buggy re-entrant/self-cancel paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)