### PR TITLE
fix(stt): prevent repeated interruption resets

### DIFF
--- a/src/pipecat/services/deepgram.py
+++ b/src/pipecat/services/deepgram.py
@@ -1300,11 +1300,11 @@ class DeepgramSTTService(STTService):
 
     async def _handle_user_speaking(self):
 
-        await self.push_frame(StartInterruptionFrame())
         if self._user_speaking == True: return
 
         self._user_speaking = True
 
+        await self.push_frame(StartInterruptionFrame())
         await self.push_frame(UserStartedSpeakingFrame())
 
     async def _handle_user_silence(self):
@@ -1380,7 +1380,7 @@ class DeepgramSTTService(STTService):
 
         last_interim_delay = current_time - self._last_interim_time
 
-        if last_interim_delay > FALSE_INTERIM_SECONDS: return
+        if last_interim_delay <= FALSE_INTERIM_SECONDS: return
 
         logger.debug("False interim detected")
 

--- a/src/pipecat/services/soniox.py
+++ b/src/pipecat/services/soniox.py
@@ -1269,7 +1269,7 @@ class SonioxSTTService(STTService):
 
         last_interim_delay = current_time - self._last_interim_time
 
-        if last_interim_delay > FALSE_INTERIM_SECONDS:
+        if last_interim_delay <= FALSE_INTERIM_SECONDS:
             return
 
         logger.debug("🚨 False interim detected - triggering user silence")


### PR DESCRIPTION
## Root cause
Deepgram emitted StartInterruptionFrame before checking whether the user was already speaking, so every interim reset the whole pipeline. Deepgram and Soniox also inverted the false-interim timeout comparison, marking the user silent while the interim was still fresh and allowing another immediate interruption.

CloudWatch showed repeated PJSIP output sink/clock cancellations milliseconds apart on both Deepgram and Soniox calls.

## Fix
- Emit Deepgram interruption frames only on the speaking-state transition.
- Trigger false-interim silence only after the configured timeout for Deepgram and Soniox.

## Verification
- Python compileall for both services.
- Direct async state checks for one interruption per utterance and timeout behavior.